### PR TITLE
Use rawurlencode instead of urlencode

### DIFF
--- a/php/OAuthSimple.php
+++ b/php/OAuthSimple.php
@@ -330,7 +330,7 @@ class OAuthSimple {
             return '';
         if (is_array($string))
             throw new OAuthSimpleException('Array passed to _oauthEscape');
-        $string = urlencode($string);
+        $string = rawurlencode($string);
         $string = str_replace('+','%20',$string);
         $string = str_replace('!','%21',$string);
         $string = str_replace('*','%2A',$string);


### PR DESCRIPTION
Oauth specifies that the url should be encoded according to  RFC3986. In PHP 5.3.0 and greater, this is found in `rawurlencode`. This patch changes the library to use `rawurlencode` instead of `urlencode`.

Note that in earlier versions of PHP, there is a bug where `rawurlencode` encodes the `~`, which is incorrect. It might be appropriate for this library to work around that bug.

Here's a random source: http://www.marcworrell.com/article-2943-en.html
