### PR TITLE
Removed the closing PHP tag

### DIFF
--- a/php/OAuthSimple.php
+++ b/php/OAuthSimple.php
@@ -415,4 +415,3 @@ class OAuthSimple {
         }
     }
 }
-?>


### PR DESCRIPTION
I removed the closing PHP tag from the library. This prevents unexpected, spurious output in case of a bad copy-and-paste where you have some extra whitespace at end of the file. This causes dreaded "headers already sent" errors and is just a good PHP coding practice anyways.
