### PR TITLE
Using empty() on a string causes invalid signatures if the string=0

### DIFF
--- a/php/OAuthSimple.php
+++ b/php/OAuthSimple.php
@@ -326,7 +326,7 @@ class OAuthSimple {
     function _oauthEscape($string) {
         if ($string === 0)
             return 0;
-        if (empty($string))
+        if (strlen($string) == 0)
             return '';
         if (is_array($string))
             throw new OAuthSimpleException('Array passed to _oauthEscape');


### PR DESCRIPTION
Using empty causes invalid signatures when a parameter has the value of `0`. PHP evaluates that to true.

```
php -r '$string="0"; var_dump(empty($string));'
bool(true)
```
