### PR TITLE
Nonce is sometimes shorter than expected

### DIFF
--- a/php/OAuthSimple.php
+++ b/php/OAuthSimple.php
@@ -506,4 +506,27 @@ class OAuthSimple {
 }
 
 class OAuthSimpleException extends Exception {
+	
+	public function __construct($err, $isDebug = FALSE) 
+	{
+		self::log_error($err);
+		if ($isDebug)
+		{
+			self::display_error($err, TRUE);
+		}
+	}
+	
+	public static function log_error($err)
+	{
+		error_log($err, 0);		
+	}
+	
+	public static function display_error($err, $kill = FALSE)
+	{
+		print_r($err);
+		if ($kill === FALSE)
+		{
+			die();
+		}
+	}
 }


### PR DESCRIPTION
Every once in a while my OAuth requests would fail with an authorization denied error.  I eventually noticed that every failed request I sent had a 4 character nonce, which seems a bug since _getNonce() is given a length of 5 in the code.

When $rnum is exactly equal to the length of the string $_nonce_chars, the substring it extracts ends up being the empty string, which causes a shorter nonce than expected.  The solution is to restrict $rnum to be between 0 and $cLength-1.

BTW, thanks for the library :)
