### PR TITLE
Update OAuthSimple.pm

### DIFF
--- a/perl/OAuthSimple.pm
+++ b/perl/OAuthSimple.pm
@@ -617,8 +617,8 @@ see .sign()
 	    if(defined($this->{_secrets}->{oauth_secret})) {
             $secretKey .= $this->_oauthEscape($this->{_secrets}->{oauth_secret});
         }
-        if (empty($normalizedParameters)) {
-            $normalizedParameters = $this->_normalizedParameters();
+        if (!empty($normalizedParameters)) {
+            $normalizedParameters = $this->_oauthEscape($normalizedParameters);
         }
         if ($this->{_parameters}->{oauth_signature_method} eq 'PLAINTEXT') {
             return $secretKey;

--- a/perl/OAuthSimple.pm
+++ b/perl/OAuthSimple.pm
@@ -625,7 +625,7 @@ see .sign()
         } elsif ($this->{_parameters}->{oauth_signature_method} eq 'HMAC-SHA1') {
             $this->{sbs} = $this->_oauthEscape($this->{_action}).'&'.$this->_oauthEscape($this->{_path}).'&'.$normalizedParameters;
             # For what it's worth, I prefer long form method calls like this since it identifies the source package.
-            return MIME::Base64::encode_base64(Digest::SHA::hmac_sha1($this->{sbs},$secretKey));
+            return MIME::Base64::encode_base64(Digest::SHA::hmac_sha1($this->{sbs},$secretKey),'');
         } else {
             Error::throw OAuthSimpleException('Unknown signature method for OAuthSimple');
         }


### PR DESCRIPTION
The fix for "new line" character that is being appended to the signature converted to base64. This makes the signature compare fail on the server side.