### PR TITLE
Again update of OAuthSimple.php

### DIFF
--- a/php/OAuthSimple.php
+++ b/php/OAuthSimple.php
@@ -490,8 +490,8 @@ class OAuthSimple {
 		{
             $secretKey .= self::_oauthEscape($this->_secrets['oauth_secret']);
         }
-        if(empty($parameters)){
-            $parameters = $this->_normalizedParameters();
+        if(!empty($parameters)){
+            $parameters = urlencode($parameters);
         }
         switch($this->_parameters['oauth_signature_method'])
         {

--- a/python/OAuthSimple/OAuthSimple.py
+++ b/python/OAuthSimple/OAuthSimple.py
@@ -236,7 +236,7 @@ class OAuthSimple:
         elif (self._parameters['oauth_signature_method'] == 'HMAC-SHA1'):
             self.sbs = '&'.join([self._oauthEscape(self._action),
                                 self._oauthEscape(self._path),
-                                normParamString])
+                                self._oauthEscape(normParamString)])
         return base64.b64encode(hmac.new(secretKey,
                                 self.sbs,
                                 hashlib.sha1).digest())


### PR DESCRIPTION
As we discuss here is the change similar to Perl version.
Making signature base string generation according to RFC 5849 (http://tools.ietf.org/html/rfc5849)