### PR TITLE
Fix checking for an at-sign filename $paramValue.

### DIFF
--- a/php/OAuthSimple.php
+++ b/php/OAuthSimple.php
@@ -438,21 +438,22 @@ class OAuthSimple {
                     continue;
                 }
             // Read parameters from a file. Hope you're practicing safe PHP.
-            if (strpos($paramValue, '@') !== 0 && !file_exists(substr($paramValue, 1)))
-			{
-				if (is_array($paramValue))
-				{
-					$normalized_keys[self::_oauthEscape($paramName)] = array();
-					foreach($paramValue as $item)
-					{
-						array_push($normalized_keys[self::_oauthEscape($paramName)],  self::_oauthEscape($item));
-					}
-				}
-				else
-				{
-					$normalized_keys[self::_oauthEscape($paramName)] = self::_oauthEscape($paramValue);
-				}
-			}
+            if (strpos($paramValue, '@') === 0 && file_exists(substr($paramValue, 1)))
+            {
+		        continue;
+            }
+            if (is_array($paramValue))
+            {
+                $normalized_keys[self::_oauthEscape($paramName)] = array();
+        		foreach($paramValue as $item)
+        		{
+        			array_push($normalized_keys[self::_oauthEscape($paramName)],  self::_oauthEscape($item));
+        		}
+        	}
+        	else
+        	{
+        		$normalized_keys[self::_oauthEscape($paramName)] = self::_oauthEscape($paramValue);
+        	}
         }
 
 		ksort($normalized_keys);


### PR DESCRIPTION
In 7e2146ba3c925f437d298155ad5a43445678af0f the original intention of this code was to look for an at-sign in the first character of $paramValue. If it was found, the rest of the $paramValue string was checked to see if it was an existing file. This was for CURL interpreting parameter values beginning with at-signs as the names of files to be read in. It is not specific to PHP, as the comments suggest.

In 942a4d25c9646c3509fc4d0bc73369c47d5be642, it appears that somebody tried reversing the logic of the if statement refactoring the code, but did not change the && operator to ||. This generally doesn't impact most users, as parameter values typically do not begin with an at-sign and are not files that exist. But, it will cause issues with strings that begin with at-signs, and causes an attempt to see if a file exists for every parameter.

I did not change the && operator to ||, as that would still cause a file existing check on each parameter. Instead, I restored the original logic.
