### PR TITLE
Fix ReferenceError: module is not defined

### DIFF
--- a/js/OAuthSimple.js
+++ b/js/OAuthSimple.js
@@ -490,6 +490,6 @@ if (OAuthSimple === undefined)
 
 
 // CommonJS Support
-if (module && exports) {
+if (typeof exports === 'object' && typeof module !== 'undefined') { 
     module.exports = OAuthSimple;
 }


### PR DESCRIPTION
Check module.exports being defined.
Critical for angular not loading script if it is invalid.